### PR TITLE
"missing )" でexitせずにエラーを投げる

### DIFF
--- a/lib/re_expand/Generator.rb
+++ b/lib/re_expand/Generator.rb
@@ -234,8 +234,7 @@ module ExpandRuby
           n2.pars = @pars.dup
           return [n1, n2]
         else
-          puts 'missing )'
-          exit
+          raise 'missing )'
         end
       else
         startnode = Node.new


### PR DESCRIPTION
ライブラリにprocessを落とされると使う側はどうしようもないので、エラーをraiseするようにしました

こうすると

``` ruby
begin
  p "(a|b)".expand
  p "(a|)".expand
rescue => e
  p e
end
```

こうなります

```
["a", "b"]
#<RuntimeError: missing )>
```
